### PR TITLE
Bug in how to defined the mid-points

### DIFF
--- a/lessons/04_spreadout/03_Heat_Equation_2D_Explicit.ipynb
+++ b/lessons/04_spreadout/03_Heat_Equation_2D_Explicit.ipynb
@@ -319,8 +319,8 @@
      "input": [
       "def ftcs(T, nt, alpha, dt, dx, dy):\n",
       "\n",
-      "    j_mid = (numpy.shape(T)[0]+1)/2\n",
-      "    i_mid = (numpy.shape(T)[1]+1)/2\n",
+      "    j_mid = (numpy.shape(T)[0])/2\n",
+      "    i_mid = (numpy.shape(T)[1])/2\n",
       "    \n",
       "    for n in range(nt):\n",
       "        Tn = T.copy()\n",


### PR DESCRIPTION
j_mid = (numpy.shape(T)[0]+1)/2
i_mid = (numpy.shape(T)[1]+1)/2 are not the mids point
for example if T is 5x5 then (j_mid, i_mid) = (3,3) according to the definition and
should be (2,2) cause the indeces go from 0 to 4. So the +1 shouldn't be there..

In the case of nx=ny even we don't have a mid point but we have to choose one, so it will work without the +1. 
