### PR TITLE
fix header formatting throughout modules 1-4

### DIFF
--- a/lessons/01_phugoid/01_02_Phugoid_Oscillation.ipynb
+++ b/lessons/01_phugoid/01_02_Phugoid_Oscillation.ipynb
@@ -753,7 +753,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of this notebook."
+    "###### The cell below loads the style of this notebook."
    ]
   },
   {

--- a/lessons/01_phugoid/01_03_PhugoidFullModel.ipynb
+++ b/lessons/01_phugoid/01_03_PhugoidFullModel.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "source": [
     "![Image](./figures/glider_forces-lesson3.png)\n",
-    "####Figure 1. Forces with a positive trajectory angle."
+    "#### Figure 1. Forces with a positive trajectory angle."
    ]
   },
   {
@@ -740,7 +740,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/01_phugoid/01_04_Second_Order_Methods.ipynb
+++ b/lessons/01_phugoid/01_04_Second_Order_Methods.ipynb
@@ -991,7 +991,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/01_phugoid/Rocket_Assignment.ipynb
+++ b/lessons/01_phugoid/Rocket_Assignment.ipynb
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Assessment:\n",
+    "## Assessment:\n",
     "\n",
     "To check your answers, you can register for [MAE 6286: Practical Numerical Methods with Python](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about).\n",
     "\n",
@@ -81,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Derivation of the rocket equations"
+    "## Derivation of the rocket equations"
    ]
   },
   {
@@ -165,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "####Figure 1. Control volume of the rocket."
+    "#### Figure 1. Control volume of the rocket."
    ]
   },
   {
@@ -201,7 +201,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/02_spacetime/02_01_1DConvection.ipynb
+++ b/lessons/02_spacetime/02_01_1DConvection.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "source": [
     "![characteristics](figures/characteristics.png)\n",
-    "####Characteristic curves for positive wave speed."
+    "#### Characteristic curves for positive wave speed."
    ]
   },
   {
@@ -154,7 +154,7 @@
    "metadata": {},
    "source": [
     "![FDapproxiamtions](figures/FDapproxiamtions.png)\n",
-    "####Three finite-difference approximations at $x_i$."
+    "#### Three finite-difference approximations at $x_i$."
    ]
   },
   {
@@ -194,7 +194,7 @@
    "metadata": {},
    "source": [
     "![FTBS_stencil](figures/FTBS_stencil.png)\n",
-    "####Stencil for the \"forward-time/backward-space\" scheme."
+    "#### Stencil for the \"forward-time/backward-space\" scheme."
    ]
   },
   {
@@ -247,7 +247,7 @@
    "metadata": {},
    "source": [
     "![squarewave](figures/squarewave.png)\n",
-    "####Square wave initial condition."
+    "#### Square wave initial condition."
    ]
   },
   {
@@ -604,7 +604,7 @@
    "metadata": {},
    "source": [
     "![vectorizedstencil](figures/vectorizedstencil.png)\n",
-    "####Sketch to explain vectorized stencil operation."
+    "#### Sketch to explain vectorized stencil operation."
    ]
   },
   {
@@ -671,7 +671,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/02_spacetime/02_02_CFLCondition.ipynb
+++ b/lessons/02_spacetime/02_02_CFLCondition.ipynb
@@ -243,7 +243,7 @@
    "metadata": {},
    "source": [
     "![CFLcondition](figures/CFLcondition.png)\n",
-    "####Graphical interpretation of the CFL condition."
+    "#### Graphical interpretation of the CFL condition."
    ]
   },
   {
@@ -453,7 +453,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/02_spacetime/02_03_1DDiffusion.ipynb
+++ b/lessons/02_spacetime/02_03_1DDiffusion.ipynb
@@ -545,7 +545,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/02_spacetime/02_04_1DBurgers.ipynb
+++ b/lessons/02_spacetime/02_04_1DBurgers.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Initial and Boundary Conditions\n",
+    "### Initial and Boundary Conditions\n",
     "\n",
     "To examine some interesting properties of Burgers' equation, it is helpful to use different initial and boundary conditions than we've been using for previous steps.  \n",
     "\n",
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Saving Time with SymPy\n",
+    "### Saving Time with SymPy\n",
     "\n",
     "\n",
     "The initial condition we're using for Burgers' Equation can be a bit of a pain to evaluate by hand.  The derivative $\\frac{\\partial \\phi}{\\partial x}$ isn't too terribly difficult, but it would be easy to drop a sign or forget a factor of $x$ somewhere, so we're going to use SymPy to help us out.  \n",
@@ -365,7 +365,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Now what?\n",
+    "### Now what?\n",
     "\n",
     "\n",
     "Now that we have the Pythonic version of our derivative, we can finish writing out the full initial condition equation and then translate it into a usable Python expression.  For this, we'll use the *lambdify* function, which takes a SymPy symbolic equation and turns it into a callable function.  "
@@ -397,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Lambdify\n",
+    "### Lambdify\n",
     "\n",
     "To lambdify this expression into a useable function, we tell lambdify which variables to request and the function we want to plug them in to."
    ]
@@ -426,7 +426,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###Back to Burgers' Equation\n",
+    "### Back to Burgers' Equation\n",
     "\n",
     "Now that we have the initial conditions set up, we can proceed and finish setting up the problem.  We can generate the plot of the initial condition using our lambdify-ed function."
    ]
@@ -1089,7 +1089,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/03_wave/03_01_conservationLaw.ipynb
+++ b/lessons/03_wave/03_01_conservationLaw.ipynb
@@ -7812,7 +7812,7 @@
    "metadata": {},
    "source": [
     "![FTBS_stencil](./figures/FTBS_stencil.png)\n",
-    "####Figure 4. Stencil of forward-time/backward-space."
+    "#### Figure 4. Stencil of forward-time/backward-space."
    ]
   },
   {
@@ -27880,7 +27880,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/03_wave/03_02_convectionSchemes.ipynb
+++ b/lessons/03_wave/03_02_convectionSchemes.ipynb
@@ -167,7 +167,7 @@
     "Before we do any coding, let's think about the equation a little bit. The wave speed $u_{\\rm wave}$ is $-1$ for $\\rho = \\rho_{\\rm max}$ and $\\rho \\leq \\rho_{\\rm max}/2$, making all velocities negative. We should see a solution moving left, maintaining the shock geometry.\n",
     "\n",
     "![squarewave](./figures/squarewave.png)\n",
-    "####Figure 1. The exact solution is a shock wave moving left.\n",
+    "#### Figure 1. The exact solution is a shock wave moving left.\n",
     "\n",
     "Now to some coding! First, let's define some useful functions and prepare to make some nice animations later."
    ]
@@ -272,10 +272,10 @@
    "metadata": {},
    "source": [
     "![Stencil of the forward-time central scheme](./figures/FD-stencil_FTCS.png)\n",
-    "####Figure 2. Stencil of the forward-time/central scheme.\n",
+    "#### Figure 2. Stencil of the forward-time/central scheme.\n",
     "\n",
     "![Stencil of the Lax-Friedrichs scheme](./figures/FD-stencil_LF.png)\n",
-    "####Figure 3. Stencil of the Lax-Friedrichs scheme."
+    "#### Figure 3. Stencil of the Lax-Friedrichs scheme."
    ]
   },
   {
@@ -39132,7 +39132,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/03_wave/03_03_aBetterModel.ipynb
+++ b/lessons/03_wave/03_03_aBetterModel.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "source": [
     "![velocity_and_flux](./figures/velocity_and_flux.png)\n",
-    "####Figure 1. Traffic speed (left) and flux (right) vs. density."
+    "#### Figure 1. Traffic speed (left) and flux (right) vs. density."
    ]
   },
   {
@@ -9317,7 +9317,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/03_wave/03_04_MUSCL.ipynb
+++ b/lessons/03_wave/03_04_MUSCL.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "![finite volume](./figures/finite_volume.png)\n",
     "\n",
-    "####Figure 2. Discretizing a 1D domain into finite volumes."
+    "#### Figure 2. Discretizing a 1D domain into finite volumes."
    ]
   },
   {
@@ -157,7 +157,7 @@
    "source": [
     "![Riemann-shocktube](./figures/Riemann-shocktube.png)\n",
     "\n",
-    "####Figure 3. The shock tube: a Riemann problem for Euler's equations. Physical space (top) and $x, t$ space (bottom)."
+    "#### Figure 3. The shock tube: a Riemann problem for Euler's equations. Physical space (top) and $x, t$ space (bottom)."
    ]
   },
   {
@@ -179,7 +179,7 @@
    "source": [
     "![many_Rieman_problems](./figures/many_Rieman_problems.png)\n",
     "\n",
-    "####Figure 4. Riemann problems on each cell boundary."
+    "#### Figure 4. Riemann problems on each cell boundary."
    ]
   },
   {
@@ -6679,7 +6679,7 @@
    "source": [
     "<img src=\"./figures/cell_boundaries.svg\">\n",
     "\n",
-    "####Figure 5. Piecewise linear approximation of the solution."
+    "#### Figure 5. Piecewise linear approximation of the solution."
    ]
   },
   {
@@ -13280,7 +13280,7 @@
    "source": [
     "---\n",
     "\n",
-    "######The cell below loads the style of the notebook."
+    "###### The cell below loads the style of the notebook."
    ]
   },
   {

--- a/lessons/03_wave/03_05_Sods_Shock_Tube.ipynb
+++ b/lessons/03_wave/03_05_Sods_Shock_Tube.ipynb
@@ -306,7 +306,7 @@
       "![shock_analytic](./figures/shock_tube_.01.png)\n",
       ". \n",
       "\n",
-      "####Figure 2. Analytical solution for Sod's first test."
+      "#### Figure 2. Analytical solution for Sod's first test."
      ]
     },
     {
@@ -344,7 +344,7 @@
       "![richtmyer](./figures/richtmyer.png)\n",
       "\n",
       "\n",
-      "####Figure 3. Stencil of Richtmyer scheme."
+      "#### Figure 3. Stencil of Richtmyer scheme."
      ]
     },
     {
@@ -383,7 +383,7 @@
      "source": [
       "---\n",
       "\n",
-      "######The cell below loads the style of the notebook."
+      "###### The cell below loads the style of the notebook."
      ]
     },
     {

--- a/lessons/04_spreadout/04_00_Python_Function_Quirks.ipynb
+++ b/lessons/04_spreadout/04_00_Python_Function_Quirks.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#Python Names"
+    "# Python Names"
    ]
   },
   {
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Assigning variables"
+    "## Assigning variables"
    ]
   },
   {
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##What does this have to do with functions?"
+    "## What does this have to do with functions?"
    ]
   },
   {
@@ -249,7 +249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##What if we change the names?"
+    "## What if we change the names?"
    ]
   },
   {
@@ -291,7 +291,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##What do we do?"
+    "## What do we do?"
    ]
   },
   {

--- a/lessons/04_spreadout/04_01_Heat_Equation_1D_Explicit.ipynb
+++ b/lessons/04_spreadout/04_01_Heat_Equation_1D_Explicit.ipynb
@@ -250,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#####Note\n",
+    "##### Note\n",
     "-----\n",
     "We are sending a *copy* of `Ti` to the function `ftcs`.  Sending a copy insures that the value of `Ti` remains unchanged for us to reuse.  \n",
     "\n",


### PR DESCRIPTION
Recent Jupyter update seems to have changed Markdown behavior regarding
headline formatting.

Previously, a header was defined in markdown by using a variable number
of # signs followed by the text of the header.

In the new version, there must be a space separating the header text
from the # signs or it doesn't render