### PR TITLE
Changed 'centrifugal acceleration' to 'centripetal acceleration' in '…

### DIFF
--- a/lessons/01_phugoid/01_01_Phugoid_Theory.ipynb
+++ b/lessons/01_phugoid/01_01_Phugoid_Theory.ipynb
@@ -209,7 +209,7 @@
     "L- W \\cos \\theta = \\frac{W}{g} \\frac{v^2}{R}\n",
     "\\end{equation}$$\n",
     "\n",
-    "where $R$ is the radius of curvature of the trajectory, and $g$ the acceleration of gravity. Recall that the centrifugal acceleration is $v^2/R$. Rearrange this by dividing the equation by the weight, and use the expression we found for $L/W$, above. The following equation results:\n",
+    "where $R$ is the radius of curvature of the trajectory, and $g$ the acceleration of gravity. Recall that the centripetal acceleration is $v^2/R$. Rearrange this by dividing the equation by the weight, and use the expression we found for $L/W$, above. The following equation results:\n",
     "\n",
     "$$\\begin{equation}\n",
     "\\frac{v^2}{v_t^2}-\\cos \\theta = \\frac{v^2}{g R}\n",


### PR DESCRIPTION
…Phugoid Theory'

In any circular motion of a body, the body continuously falls accelerating 'towards center' which we call 'centripetal acceleration'. This 'centrepetal acceleration' makes the body feel a fictitious force acting 'away from the center' which we call 'centrifugal force'.

Thus I think what we encounter in a typical circular motion is 'centripetal aceleration' as opposed to 'centrifugal acceleration'