### PR TITLE
clarify why 2nd-order derivative of psi w.r.t. x is zero at top surface

### DIFF
--- a/lessons/05_relax/05_05_Stokes.Flow.ipynb
+++ b/lessons/05_relax/05_05_Stokes.Flow.ipynb
@@ -199,7 +199,7 @@
     "\n",
     "has no $\\psi$ value.  Instead, we need a way to represent the boundary conditions for $\\omega$ in terms of $\\psi$.  \n",
     "\n",
-    "Consider the equation $\\nabla ^2 \\psi = -\\omega$ along the top surface of the cavity (the moving surface).  There can't be any velocity in the $y$-direction because the surface is solid, so $\\frac{\\partial ^2 \\psi}{\\partial x^2}$ goes to zero and the equation simplifies to\n",
+    "Consider the equation $\\nabla ^2 \\psi = -\\omega$ along the top surface of the cavity (the moving surface).  The streamfunction $\\psi$ along $x$-direction is a zero constant, so $\\frac{\\partial ^2 \\psi}{\\partial x^2}$ goes to zero and the equation simplifies to\n",
     "\n",
     "\\begin{equation}\n",
     "\\frac{\\partial ^2 \\psi}{\\partial y^2} = -\\omega\n",
@@ -527,10 +527,11 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [Root]",
    "language": "python",
-   "name": "python3"
+   "name": "Python [Root]"
   },
   "language_info": {
    "codemirror_mode": {
@@ -542,7 +543,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Thanks @morrill for spotting this.

When deriving the BCs for vorticity equations at the top surface, $\partial^2 \psi / \partial x^2$ is zero. This is because the streamfunction along the x-axis at the top surface is a zero-constant.