### PR TITLE
Fix markdown heading formatting

### DIFF
--- a/lessons/00_getting_started/00_01_Intro_to_the_command_line_redhat.md
+++ b/lessons/00_getting_started/00_01_Intro_to_the_command_line_redhat.md
@@ -1,4 +1,4 @@
-#Intro to the command line
+# Intro to the command line
 
 Welcome! The command line can be one of the most powerful ways to interact with
 a variety of computer systems, but it can also be a little confusing at first
@@ -28,7 +28,7 @@ and hitting \<Enter\>. (From now on, after typing in a command, just hit
 
 ![whoami](./images/1.whoami.gif)
 
-##Where am I?
+## Where am I?
 
 We know who we are, time to find out *where* we are. You can always find out
 what folder you're in by using the "print working directory" command, or `pwd`.
@@ -46,7 +46,7 @@ If you're using your own Linux machine, the home directory is probably
 `/home/<username>`. If you're on a Mac, the home directory is
 `/Users/<username>` (they like to be different).
 
-##What's in here?
+## What's in here?
 
 We know who we are and where we are, now it's time to figure out what's in here.
 We use the "list" command, `ls`, to view any files or directories that are in
@@ -63,7 +63,7 @@ created by default in Red Hat Linux. Your home folder is actually the same
 folder as your Titan network drive on Windows, so you may have other files and
 folders in your home directory.
 
-##How do I go there?
+## How do I go there?
 
 To navigate to a new folder, we use the change directory command, `cd`, followed
 by the name of the folder. While you *can* type out the full folder name, it's
@@ -83,7 +83,7 @@ directory to get the hang of moving around.
 
 ![cd](./images/4.cd.gif)
 
-###Multiple tab-completions
+### Multiple tab-completions
 
 If there are multiple possible completions for a partial directory name, you can
 ask the terminal to display them by hitting TAB twice. Try entering
@@ -97,7 +97,7 @@ a `c` and Tab-complete `Documents`.
 
 ![cdtabtab](./images/5.cdtabtab.gif)
 
-##Quick config step
+## Quick config step
 
 Now that we have a handle on basic terminal navigation, we are going to make a
 few tweaks to this setup to make it friendlier. Copy the two lines below by
@@ -124,7 +124,7 @@ It should look a little something like this:
 
 ![image](./images/6.bashrc.gif)
 
-##Fire up a jupyter notebook!
+## Fire up a jupyter notebook!
 
 It's time to get started! If you're at GW then everything is already installed,
 just run

--- a/lessons/00_getting_started/00_02_Installing_Jupyter.md
+++ b/lessons/00_getting_started/00_02_Installing_Jupyter.md
@@ -1,12 +1,12 @@
-#Jupyter Install
+# Jupyter Install
 
 This guide is to help you get Jupyter notebooks up and running on your personal computer.  
 
-##1. Install Anaconda
+## 1. Install Anaconda
 
 There are several ways to install Python and Jupyter and all of the required libraries to complete this course.  You are welcome to try out any of them, but we **strongly** suggest using the Anaconda Python Distribution.  It is up-to-date (unlike the versions of Python that may already exist on your Linux or OSX machine) and it also comes with `conda`.  We'll get to `conda` a little later, but believe us, it's awesome and you want to have it.
 
-###Download the installer
+### Download the installer
 
 First download the Anaconda installer.  Visit http://continuum.io/downloads to download the appropriate installer for your operating system.
 
@@ -15,7 +15,7 @@ First download the Anaconda installer.  Visit http://continuum.io/downloads to d
 ![anaconda](./images/anaconda.download.gif)
 
 
-###Run the installer
+### Run the installer
 
 Follow the appropriate instructions for your operating system listed on the [Anaconda Install Page](http://docs.continuum.io/anaconda/install).  For Linux users, make sure to answer "yes" when the installer asks about editing your `PATH`.
 
@@ -23,7 +23,7 @@ Follow the appropriate instructions for your operating system listed on the [Ana
 
 Also note that on both Linux and OSX, you have to close the current terminal window and re-open it before the Anaconda installation will be available.
 
-##2. Install Jupyter and other libraries
+## 2. Install Jupyter and other libraries
 
 Once Anaconda is installed, you can then use the included `conda` package to install all of the necessary packages for the course.  Open a terminal and run
 
@@ -31,7 +31,7 @@ Once Anaconda is installed, you can then use the included `conda` package to ins
 conda install jupyter numpy scipy sympy matplotlib
 ```
 
-##3. Test your installation
+## 3. Test your installation
 Once `conda` is finished you should be ready to go!  Open a terminal and run
 
 ```Bash

--- a/lessons/00_getting_started/00_03_Intro_to_Jupyter_notebook.md
+++ b/lessons/00_getting_started/00_03_Intro_to_Jupyter_notebook.md
@@ -25,7 +25,7 @@ This will bring up a simple file-browser that will show the contents of the dire
 
 ![newnotebook](./images/newnotebook.gif)
 
-##Executing a code cell
+## Executing a code cell
 
 Below the toolbars, you'll see a single code cell, prepended with `In [ ]:`.  This cell can contain an arbitrarily long code segment, but we'll start with a simple one liner.  In that lone code cell, type
 
@@ -50,10 +50,10 @@ The whole procedure should look something like this:
 
 ![runandprint](./images/runandprint.gif)
 
-##The Kernel
+## The Kernel
 Don't worry too much about what the "kernel" is, but the main point to remember here is that we can assign a variable in one cell but still access it in a separate cell.  The cells are ways for *us* to divide up our thoughts and our code, but everything is connected underneath.  
 
-##Overwriting variables
+## Overwriting variables
 
 Since each cell is interacting with the same Python instance, if we give `x` a new value and then enter `print(x)` we'll get that new value.  That's pretty straight forward —but what if we then delete the cell where we gave `x` a new value?
 
@@ -63,7 +63,7 @@ Let's take a look!
 
 Even though we deleted the cell where we assigned `x = 7`, the assignment is still valid.  In fact, the assignment will remain valid until we explicitly execute a cell that sets x equal to a new value, or until we completely restart this Jupyter Notebook instance.  
 
-##Markdown
+## Markdown
 Markdown is a *writing format* that makes it easy to type well-formatted text that is rendered into properly formatted XHTML.  It's seriously awesome.  Cells in Jupyter notebooks can be used for many things: to run Python, to embed media, or to write text in Markdown.  This allows us to write notes about what we're doing, what the code is doing, what we're *trying* to do, whatever we like! These notes can be for ourselves, to document our work, or to share with others.
 
 To create a Markdown cell in a notebook, click on an empty cell, then click on the Dropdown list (by default, it will say "Code") and select "Markdown"—as shown below.
@@ -72,7 +72,7 @@ Markdown is also (sort of) code, so after you type some text, you will also hit 
 
 ![render](./images/rendermarkdown.gif)
 
-##Markdown Math
+## Markdown Math
 
 Markdown can do more than just render simple text, it can also render LaTeX-style equations using **MathJax**!
 
@@ -87,7 +87,7 @@ Markdown can do more than just render simple text, it can also render LaTeX-styl
 
 Be aware that math typesetting is handled by MathJax and not by LaTeX.  While the vast majority of MathJax syntax is identical to LaTeX, there are a few small differences (especially when it comes to matrix commands).  So if you find something doesn't typeset the way you expect, Google around to make sure you're using the correct command.
 
-##More Markdown Syntax
+## More Markdown Syntax
 There are several references to learn Markdown tricks, but we especially like the summary by [John Gruber](http://daringfireball.net/projects/markdown/syntax).  A few features that we find particularly useful are listed below.
 
 For italics, wrap text in single `*`: `*this will be italic*` 
@@ -99,7 +99,7 @@ For a bulleted list, start the line with an `*`, then type a space followed by t
 * and another
 ```
 
-##Moving Cells Around
+## Moving Cells Around
 You'll often find that you want to add or delete cells, or just move them around.  To move a cell, just click on it to select it, then use the Up- and Down-arrows in the toolbar to change the position of the cell.
 
 ![movecells](./images/movingcells.gif)

--- a/lessons/00_getting_started/00_04_Intro_to_git.md
+++ b/lessons/00_getting_started/00_04_Intro_to_git.md
@@ -1,12 +1,12 @@
 Based heavily on [this intro](https://github.com/barbagroup/teaching-materials/blob/master/git/00-GettingStarted.md) by @anushkrish.
 
-#Intro to git
+# Intro to git
 
 Version control is a method to keep track of changes that we introduce to a set of files or documents that we use. This is especially useful when writing code because most code is written and improved through incremental changes. Version control allows us to compare newer versions of code with older versions, and investigate when certain changes were made that may have caused the code to malfunction. Git is a one such version control software, which was created by Linus Torvalds to help with writing the Linux kernel.
 
 Version control systems store files in a directory known as a repository. Apart from the files, a repository also contains information about the history of each file, and all the edits that were made. In this tutorial, we will learn how to create a Git repository, add files to it, make changes to those files, and record the history of those changes.
 
-##Before anything else
+## Before anything else
 When we write commit messages (this is all coming up) we need to use a text editor.  The default text editor, `vim`, is... unfriendly.  It's incredibly powerful but not the way you want to start off.  In light of that, let's change the default editor to the more friendly `nano` by doing the following in a terminal (we only do this once, the changes will persist):
 
 ```
@@ -14,7 +14,7 @@ echo "export EDITOR=nano" >> .bashrc
 source .bashrc
 ```
 
-##`git config`
+## `git config`
 Before we use Git, we have to configure two small things to help track the changes we make to files.
 Please run the following two commands, filling in your personal info.  Make sure to use the same email address that you used to sign up for Github.
 
@@ -25,7 +25,7 @@ git config --global user.name "First Last"
 
 If you copy+paste these, make sure to do it one line at a time.  If you paste two lines into a terminal, it will run the first command automatically and Git will think your email address is "your.github.email".
 
-##Creating a `git` repository
+## Creating a `git` repository
 First we are going to make a new directory that will become our first git repository.  
 Do you remember the command to make a new directory?  It's `mkdir`!  We like to keep all of our `git` directories in a folder called "git".  Let's make that folder first.
 
@@ -48,7 +48,7 @@ mkdir first repo
 
 You'll actually end up with *two* folders, one called `first` and one called `repo`.
 
-###Add a Python script to the new directory
+### Add a Python script to the new directory
 
 Let's `cd` into `first_repo` and then create a quick Python script.
 
@@ -57,12 +57,12 @@ cd first_repo
 nano HelloWorld.py
 ```
 
-###What's `nano`?
+### What's `nano`?
 `nano` is a simple terminal-based text editor.  There are several incredibly powerful terminal based editors (vim, emacs) but they come with pretty steep learning curves.  `nano` is much friendlier.
 
 The file `HelloWorld.py` doesn't exist, but we run `nano HelloWorld.py` and it creates that file and opens it for editing.
 
-###Back to the script
+### Back to the script
 Type
 
 ```Python
@@ -71,7 +71,7 @@ print("Hello, World!")
 
 on the first line.  Then hit Ctrl+o to save the file, then Ctrl+x to exit `nano`.  
 
-##Initializing a repository
+## Initializing a repository
 
 Now we have a folder called `first_repo` with the script `HelloWorld.py` in it.  We want to convert this folder into a Git repository, which is easy!  
 
@@ -89,7 +89,7 @@ git init
 
 Now `first_repo` is a Git repository.
 
-##Repo status
+## Repo status
 
 We can check the status of the repository using
 
@@ -111,13 +111,13 @@ which will return the following:
 nothing added to commit but untracked files present (use "git add" to track)
 ```
 
-####What's going on here?
+#### What's going on here?
 
 * The history of the repository is stored along a timeline known as a *branch*.  We're on the "main" (and only) branch.
 * At any point of time, the user can choose to save a snapshot of all the files in the repository. Each snapshot is referred to as a *commit*. The act of saving a snapshot is referred to as *committing changes*.
 
 
-##Adding files to the repository
+## Adding files to the repository
 
 The status command also told us that we have an "Untracked file" (`HelloWorld.py`).  That means that `HelloWorld.py` isn't part of any snapshots and its history isn't being recorded by Git.
 
@@ -144,7 +144,7 @@ which gives us
 
 Note that this still does not commit the changes. The `git add` command adds the file to what is known as the staging area. This is where all the changes to the files that are ready to be committed are stored. All files in the staging area are listed under "Changes to be committed:". We can see that `HelloWorld.py` has been added to this list.
 
-##Committing changes
+## Committing changes
 
 We want to save a snapshot of the repository as it is right now; it's time to commit!
 
@@ -176,7 +176,7 @@ and you should see
 nothing to commit (working directory clean)
 ```
 
-##Editing a tracked file
+## Editing a tracked file
 
 Now, suppose you decide to make some changes to the file. Instead of printing "Hello world!", you want to display "Greetings Earth! We come in peace." Open `nano` again to edit the file
 
@@ -210,7 +210,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 ```
 You have a list of files that have been changed since the last commit, along with some tips on what you can do with them.
 
-##Viewing changes
+## Viewing changes
 
 We only changed one line in one file -- you probably remember that pretty clearly at this point.  But sometimes you might edit several lines, or go grab some coffee and come back, and find you can't remember everything you've done.  This is where `git diff` comes in.  It will show all the changes made to the current repository (even if they aren't committed yet!).  Try it out!
 
@@ -232,7 +232,7 @@ index ed708ec..ce3f2ef 100644
 
 All the lines starting with `-` are those that have been removed, and the lines beginning with `+` are the ones that have been added. In our case, we can see that `print("Hello world!")` has been removed and `print("Greetings Earth! We come in peace.")` has been added to the file.
 
-##Committing changes
+## Committing changes
 
 We want to add the changes we made to the history of the "HelloWorld.py" file.  To do this, we follow the same steps as when we first added the file.
 
@@ -262,7 +262,7 @@ git commit -m "Edit the message to sound more friendly"
 
 The `-m` flag is short for `message`.  This command will commit the changes with the message we pass to it.  No need to open `nano` this time!
 
-##Viewing a repo's history
+## Viewing a repo's history
 We have saved two snapshots of this repository.  We can look at the list of all commits using the `git log` command
 
 ```
@@ -285,7 +285,7 @@ Date:   Tue Aug 19 15:45:12 2015 -0400
     First commit. Add HelloWorld.py.
 ```
 
-##Uploading your repository to Github
+## Uploading your repository to Github
 
 One of the nifty features of Git is that it allows you to copy the folder containing the repository to any other location, and all the information regarding the history of the repository is also transferred automatically. It also allows you to create a backup of your repository on a remote server. Services like Github run servers where you can host your repositories for free. 
 
@@ -306,7 +306,7 @@ Of course, you should make the appropriate changes so it reflects your Github us
 
 `git push` is used to push all changes from the local repository to the remote repository. The `-u` flag is only used the first time you push a new branch.
 
-###`403 Forbidden while accessing...`
+### `403 Forbidden while accessing...`
 Older version of `git` will sometimes throw errors while attempting to push to GitHub or any other site that uses HTTPS authentication.  If you get the above error when trying to `git push` you can fix it with one extra line:
 
 ```
@@ -317,5 +317,5 @@ git push -u origin master
 
 Make sure to change the username and repository name to match what you have created.  If you are using an older version of `git`, the easiest solution is to upgrade, but if you can't for whatever reason, then running that extra command when you set up a new repository should fix the issue.
 
-##Look at your repo on Github
+## Look at your repo on Github
 Your changes should be reflected immediately on Github.  The URL for your repo should be `https://github.com/<your username>/first_repo`.  Take a look around.  You can look at the file(s) you pushed and also look at the commit history of your repository.  

--- a/lessons/01_phugoid/README.md
+++ b/lessons/01_phugoid/README.md
@@ -1,6 +1,6 @@
-#Module 1: The phugoid model of glider flight.
+# Module 1: The phugoid model of glider flight.
 
-##Summary
+## Summary
 
 The phugoid model motivates the learning of numerical time integration methods. The model is described by a set of two nonlinear ordinary differential equations, representing the oscillatory trajectory of an aircraft subject to longitudinal perturbations.
 
@@ -9,32 +9,32 @@ The phugoid model motivates the learning of numerical time integration methods. 
 * [Lesson 3](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/01_phugoid/01_03_PhugoidFullModel.ipynb) develops the full phugoid model and solves it with (vectorized) Euler's method. In the absence of an exact solution, the study of convergence uses a grid-refinement method, obtaining the observed order of convergence. The lesson ends with the paper-airplane challenge.
 * [Lesson 4](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/01_phugoid/01_04_Second_Order_Methods.ipynb) starts with the screencast "Euler's method is a first-order method" and develops second-order methods: explicit midpoint (modified Euler) and Runge-Kutta. It ends with a grid-refinement study.
 
-##Badge earning
+## Badge earning
 
 Completion of this module in the online course platform can earn the learner the Module 1 badge.
 
-###Description: What does this badge represent?
+### Description: What does this badge represent?
 
 The earner completed Module 1 "The phugoid model of glider flight" of the course "Practical Numerical Methods with Python" (a.k.a., numericalmooc). 
 
-###Criteria: What needs to be done to earn it?
+### Criteria: What needs to be done to earn it?
 
 To earn this badge, the learner needs to complete the graded assessment in the course platform including: answering quiz about basic numerical Python commands; answering quiz about basics of initial-value problems; completing the individual coding assignment "Rocket flight" and answering the numeric questions online. Earners should also have completed self-study of the four module lessons, by reading, reflecting on and writing their own version of the codes. This is not directly assessed, but it is assumed. Thus, earners are encouraged to provide evidence of this self-study by giving links to their code repositories or other learning objects they created in the process.
 
-###Evidence: Website (link to original digital content)
+### Evidence: Website (link to original digital content)
 
 Desirable: link to the earner's GitHub repository (or equivalent) containing the solution to the "Rocket flight" coding assignment.
 Optional: link to the earner's GitHub repository (or equivalent)  containing other codes, following the lesson.
 
-###Category: 
+### Category: 
 
 Higher education, graduate
 
-###Tags: 
+### Tags: 
 
 engineering, computation, higher education, numericalmooc, python, gwu, george washington university, lorena barba, github
 
-###Relevant Links: Is there more information on the web?
+### Relevant Links: Is there more information on the web?
 
 [Course About page](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about)
 

--- a/lessons/02_spacetime/README.md
+++ b/lessons/02_spacetime/README.md
@@ -1,7 +1,7 @@
-#Module 2: 
-##Space & Time: Introduction to numerical solution of PDEs
+# Module 2: 
+## Space & Time: Introduction to numerical solution of PDEs
 
-##Summary
+## Summary
 This module lays the foundation for numerical solution of partial differential equations (PDEs), where the unknown is a multi-variate function.
 
 * [Lesson 1](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/02_spacetime/02_01_1DConvection.ipynb) starts with the simplest model: the one-dimensional linear convection equation, and explains the finite-difference method of discretizing derivatives. It demonstrates the first-order forward-time, backward-space method and discusses truncation error. It then shows how to solve the nonlinear convection equation, and explains vectorized stencil operations.
@@ -10,29 +10,29 @@ This module lays the foundation for numerical solution of partial differential e
 * [Lesson 4](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/02_spacetime/02_04_1DBurgers.ipynb) combines previous results to demonstrate a solution of the Burgers' equation. It introduces SymPy for symbolic computations and uses periodic boundary conditions for the first time. It also demonstrates computational speed differences when using array operations.
 
 
-##Badge earning
+## Badge earning
 Completion of this module in the online course platform can earn the learner the Module 2 badge.
 
-###Description: What does this badge represent?
+### Description: What does this badge represent?
 
 The earner of this badge has completed Module 2 of the course "Practical Numerical Methods with Python." This module lays the foundation for the numerical solution of PDEs, including: one-dimensional linear convection, non-linear convection, diffusion and Burgers' equation.
 
-###Criteria: What needs to be done to earn it?
+### Criteria: What needs to be done to earn it?
 To earn this badge, the learner needs to complete the graded assessment in the course platform including: answering quiz about stencils of numerical schemes; answering quiz questions about stability and using sympy; completing the individual coding assignment "Traffic flow" and answering the numeric questions online. 
 Earners should also have completed self-study of the four module lessons, by reading, reflecting on and writing their own version of the codes. This is not directly assessed, but it is assumed. Thus, earners are encouraged to provide evidence of this self-study by giving links to their code repositories or other learning objects they created in the process.
 
-###Evidence: Website (link to original digital content)
+### Evidence: Website (link to original digital content)
 Desirable: link to the earner's GitHub repository (or equivalent) containing the solution to the "Traffic flow" coding assignment. 
 
 Optional: link to the earner's GitHub repository (or equivalent) containing other codes, following the lesson.
 
-###Category:
+### Category:
 Higher education, graduate
 
-###Tags:
+### Tags:
 engineering, computation, higher education, numericalmooc, python, gwu, george washington university, lorena barba, github
 
-###Relevant Links: Is there more information on the web?
+### Relevant Links: Is there more information on the web?
 
 [Course About page](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about)
 

--- a/lessons/03_wave/README.md
+++ b/lessons/03_wave/README.md
@@ -1,7 +1,7 @@
-#Module 3:
-##Riding the wave: convection problems
+# Module 3:
+## Riding the wave: convection problems
 
-##Summary
+## Summary
 
 This module explores in depth the solution of transport problems and conservation laws using numerical methods.
 
@@ -17,29 +17,29 @@ Lax-Friedrichs, Lax-Wendroff and MacCormack.
 
 * [Lesson 4](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/03_wave/03_04_MUSCL.ipynb) is an introduction to the finite-volume method, including study of the conservative discretization, Godunov's method and the MUSCL method.
 
-##Badge earning
+## Badge earning
 Completion of this module in the online course platform can earn the learner the Module 3 badge.
 
-###Description: What does this badge represent?
+### Description: What does this badge represent?
 The earner completed Module 3 of the course "Practical Numerical Methods with Python" (a.k.a., numericalmooc).
 
-###Criteria: What needs to be done to earn it?
+### Criteria: What needs to be done to earn it?
 To earn this badge, the learner needs to complete the graded assessment in the course platform including: 
 answering quiz questions involving symbolic calculations with the improved traffic model, and additional SymPy practice;
 answering quiz questions on convergence and truncation error; 
 completing the individual coding assignment using "Sod's shock-tube" problem and answering the numeric questions online.
 Earners should also have completed self-study of the four module lessons, by reading, reflecting on and writing their own version of the codes. This is not directly assessed, but it is assumed. Thus, earners are encouraged to provide evidence of this self-study by giving links to their code repositories or other learning objects they created in the process.
 
-###Evidence: Website (link to original digital content)
+### Evidence: Website (link to original digital content)
 Desirable: link to the earner's GitHub repository (or equivalent) containing the solution to the "Sod's shock-tube" coding assignment. Optional: link to the earner's GitHub repository (or equivalent) containing other codes, following the lesson.
 
-###Category:
+### Category:
 Higher education, graduate
 
-###Tags:
+### Tags:
 engineering, computation, higher education, numericalmooc, python, gwu, george washington university, lorena barba, github
 
-###Relevant Links: Is there more information on the web?
+### Relevant Links: Is there more information on the web?
 
 [Course About page](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about)
 

--- a/lessons/04_spreadout/README.md
+++ b/lessons/04_spreadout/README.md
@@ -1,4 +1,4 @@
-#Module 4:
+# Module 4:
 ## Spreading out: diffusion problems
 ## Summary
 This module focuses on solution of parabolic PDEs, like the diffusion equation. It introduces for the first time implicit methods and covers both one- and two-dimensional problems.
@@ -14,27 +14,27 @@ This module focuses on solution of parabolic PDEs, like the diffusion equation. 
 * [Lesson 5](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/04_spreadout/04_05_Crank-Nicolson.ipynb) is dedicated to the Crank-Nicolson scheme, including a study of spatial and time accuracy and convergence.
 * [Coding assignment](http://nbviewer.ipython.org/github/numerical-mooc/numerical-mooc/blob/master/lessons/04_spreadout/04_06_Reaction_Diffusion.ipynb) Reaction-diffusion with the Gray-Scott model in 2D.
 
-##Badge earning
+## Badge earning
 Completion of this module in the online course platform can earn the learner the Module 4 badge.
 
-###Description: What does this badge represent?
+### Description: What does this badge represent?
 The earner completed Module 4 of the course "Practical Numerical Methods with Python" (a.k.a., numericalmooc).
 
-###Criteria: What needs to be done to earn it?
+### Criteria: What needs to be done to earn it?
 To earn this badge, the learner needs to complete the graded assessment in the course platform including: answering quiz
 questions about handling boundary conditions, and completing the individual coding assignment on the Gray-Scott model of reaction-diffusion  and answering the numeric questions online.
 Earners should also have completed self-study of the five module lessons, by reading, reflecting on and writing their own version of the codes. This is not directly assessed, but it is assumed. Thus, earners are encouraged to provide evidence of this self-study by giving links to their code repositories or other learning objects they created in the process.
 
-###Evidence: Website (link to original digital content)
+### Evidence: Website (link to original digital content)
 Desirable: link to the earner's GitHub repository (or equivalent) containing the solution to the "Reaction-Diffusion" coding assignment. Optional: link to the earner's GitHub repository (or equivalent) containing other codes, following the lesson.
 
-###Category:
+### Category:
 Higher education, graduate
 
-###Tags:
+### Tags:
 engineering, computation, higher education, numericalmooc, python, gwu, george washington university, lorena barba, github
 
-###Relevant Links: Is there more information on the web?
+### Relevant Links: Is there more information on the web?
 
 [Course About page](http://openedx.seas.gwu.edu/courses/GW/MAE6286/2014_fall/about)
 

--- a/lessons/05_relax/README.md
+++ b/lessons/05_relax/README.md
@@ -1,4 +1,4 @@
-#Module 5:
+# Module 5:
 ## Relax and hold steady: elliptic problems
 ## Summary
 This course module is dedicated to the solution of elliptic PDS, like the Laplace and Poisson equations.


### PR DESCRIPTION
Github doesn't always render headings as headings if there are no spaces after the pound sign (e.g. "## Blork" renders, but "##Blork" doesn't always).